### PR TITLE
add helm-gcs plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,3 +39,4 @@ RUN helm init --client-only
 # Plugin is downloaded to /tmp, which must exist
 RUN mkdir /tmp
 RUN helm plugin install https://github.com/databus23/helm-diff
+RUN helm plugin install https://github.com/viglesiasce/helm-gcs.git


### PR DESCRIPTION
As this docker image has support for gcloud so it makes sense to install the helm-gcs plugin along with the image.