### PR TITLE
Added jq to the toolset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Trevor Hartman <trevorhartman@gmail.com>
 WORKDIR /
 
 # Enable SSL
-RUN apk --update add ca-certificates wget python curl tar
+RUN apk --update add ca-certificates wget python curl tar jq
 
 # Install gcloud and kubectl
 # kubectl will be available at /google-cloud-sdk/bin/kubectl

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This Docker image includes `helm` along with:
 - `gcloud`
 - `kubectl`
 - `envsubst`
+- `jq`
 
 And `helm` plugins:
 


### PR DESCRIPTION
As we're dealing with JSON quite a lot in the k8s environment, I find myself lost in JSON quite often e.g. to extract data from `kubectl get pod <podname> -o=json`. I know there's built in `jsonpath` support but sometimes I would like to combine outputs from different commands etc. which is where `jq` (https://stedolan.github.io/jq/) usually comes in super handy!
Wdyt?