### PR TITLE
Add ENV variable to support update of helm plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN google-cloud-sdk/bin/gcloud config set --installation component_manager/disa
 ENV FILENAME helm-${VERSION}-linux-amd64.tar.gz
 ENV HELM_URL https://storage.googleapis.com/kubernetes-helm/${FILENAME}
 
+
 RUN echo $HELM_URL
 
 RUN curl -o /tmp/$FILENAME ${HELM_URL} \
@@ -48,6 +49,8 @@ RUN set -x && \
 
 # Install Helm plugins
 RUN helm init --client-only
+# workaround for an issue in updating the binary of `helm-diff`
+ENV HELM_PLUGIN_DIR /.helm/plugins/helm-diff
 # Plugin is downloaded to /tmp, which must exist
 RUN mkdir /tmp
 RUN helm plugin install https://github.com/viglesiasce/helm-gcs.git


### PR DESCRIPTION
When upgrading the image of `devth/helm-docker:v2.9.0' to use helm `devth/helm-docker:v2.14.0` in our ci-cd pipeline, we faced an issue using `helm diff`. We got the following error:
```
fork/exec /.helm/plugins/helm-diff/bin/diff: no such file or directory
```
This folder does exist on the filesystem.
We found that the following issue exists:
https://github.com/databus23/helm-diff/issues/59

After a bit of research, we found that adding the `ENV HELM_PLUGIN_DIR` solve that problem for us.