### PR TITLE
Add Docker tag prefix, to match previous syntax

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -30,8 +30,8 @@ jobs:
         with:
           images: devth/helm
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -29,6 +29,9 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: devth/helm
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/update-helm.yaml
+++ b/.github/workflows/update-helm.yaml
@@ -97,7 +97,6 @@ jobs:
           then
             echo "Deleting git tags for ${MAJOR_VERSION}"
             git tag -d ${MAJOR_VERSION}
-            git push origin :refs/tags/${MAJOR_VERSION}
           fi
 
           git tag $MAJOR_VERSION

--- a/.github/workflows/update-helm.yaml
+++ b/.github/workflows/update-helm.yaml
@@ -77,30 +77,6 @@ jobs:
           git commit -am "$commit_message"
           git tag ${{ needs.check.outputs.release_tag }}
 
-      - name: Commit and Push - Major version tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
-        run: |
-          VERSION=${{ needs.check.outputs.release_tag }}
-          IFS="."
-          read -ra VERSION_ARRAY <<< "${VERSION}"
-          MAJOR_VERSION=${VERSION_ARRAY[0]}
-
-          echo "Got major version: ${MAJOR_VERSION}"
-
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-
-          git pull --tags
-
-          if git rev-parse "${MAJOR_VERSION}" >/dev/null 2>&1
-          then
-            echo "Deleting git tags for ${MAJOR_VERSION}"
-            git tag -d ${MAJOR_VERSION}
-          fi
-
-          git tag $MAJOR_VERSION
-
       # must push with a PAT in order to trigger downstream github actions
       - name: Push changes
         env:

--- a/.github/workflows/update-helm.yaml
+++ b/.github/workflows/update-helm.yaml
@@ -25,8 +25,8 @@ jobs:
 
           echo "issue_number: $issue_number"
           echo "issue_title: $issue_title"
-          echo "::set-output name=issue_number::${issue_number}"
-          echo "::set-output name=issue_title::${issue_title}"
+          echo "issue_number=${issue_number}" >> $GITHUB_OUTPUT
+          echo "issue_title=${issue_title}" >> $GITHUB_OUTPUT
 
       - name: Get Helm tags
         id: get_tags
@@ -34,17 +34,17 @@ jobs:
           LATEST_TAG=$(curl --silent --fail https://api.github.com/repos/helm/helm/tags | jq -r .[0].name)
           echo "Latest tag: ${LATEST_TAG}"
           echo "LATEST_TAG=${LATEST_TAG}" >> $GITHUB_ENV
-          echo "::set-output name=tag::${LATEST_TAG}"
+          echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
       - name: Compare versions
         id: compare_versions
         run: |
           if grep -q "ENV VERSION ${{ env.LATEST_TAG }}$" Dockerfile
           then
             echo "Not a new version, skipping..."
-            echo "::set-output name=release_found::false"
+            echo "release_found=false" >> $GITHUB_OUTPUT
           else
             echo "Found a new release: $LATEST_TAG"
-            echo "::set-output name=release_found::true"
+            echo "release_found=true" >> $GITHUB_OUTPUT
           fi
   update:
     name: Update Dockerfile

--- a/.github/workflows/update-helm.yaml
+++ b/.github/workflows/update-helm.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          persist-credentials: false
+          token: ${{ secrets.PAT }}
       - name: Update
         run: |
           sed -i "3s/.*/ENV VERSION ${{ needs.check.outputs.release_tag }}/" Dockerfile
@@ -79,6 +79,4 @@ jobs:
 
       # must push with a PAT in order to trigger downstream github actions
       - name: Push changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
         run: git push --follow-tags

--- a/.github/workflows/update-helm.yaml
+++ b/.github/workflows/update-helm.yaml
@@ -79,4 +79,6 @@ jobs:
 
       # must push with a PAT in order to trigger downstream github actions
       - name: Push changes
-        run: git push --follow-tags
+        run: |
+          git push
+          git push origin ${{ needs.check.outputs.release_tag }}

--- a/.github/workflows/update-helm.yaml
+++ b/.github/workflows/update-helm.yaml
@@ -15,7 +15,7 @@ jobs:
       issue_title: ${{ steps.get_issue.outputs.issue_title }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get issue that caused the workflow to run
         id: get_issue
@@ -53,7 +53,7 @@ jobs:
     if: ${{ needs.check.outputs.release_found == 'true' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Update


### PR DESCRIPTION
This is just a nice to have, since all images on docker hub before `3.12.0-rc.1` included a prefix - ideally `v3.12.0-rc.1`