### PR TITLE
fix kubectl on arm image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,31 @@
 FROM alpine:3.21.0
 
-ENV VERSION v3.17.0
+ENV VERSION=v3.17.0
 
 ARG TARGETARCH
 
-MAINTAINER Trevor Hartman <trevorhartman@gmail.com>
+LABEL maintainer="Trevor Hartman <trevorhartman@gmail.com>"
 
 WORKDIR /
 
 # Enable SSL
-RUN apk --update add ca-certificates wget python3 curl tar jq
+RUN apk --update add ca-certificates wget python3 curl tar jq gcompat
 
 # Install gcloud and kubectl
 # kubectl will be available at /google-cloud-sdk/bin/kubectl
 # This is added to $PATH
-ENV HOME /
-ENV PATH /google-cloud-sdk/bin:$PATH
-ENV CLOUDSDK_PYTHON_SITEPACKAGES 1
+ENV HOME=/
+ENV PATH=/google-cloud-sdk/bin:$PATH
+ENV CLOUDSDK_PYTHON_SITEPACKAGES=1
 
-RUN export ARCH=${TARGETARCH/amd64/x86_64}; export ARCH=${ARCH/arm64/arm}; wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-${ARCH}.tar.gz && tar -xf google-cloud-cli-linux-${ARCH}.tar.gz && rm google-cloud-cli-linux-${ARCH}.tar.gz
+RUN export ARCH=${TARGETARCH/amd64/x86_64}; export ARCH=${ARCH/arm64/arm}; wget --no-verbose https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-${ARCH}.tar.gz && tar -xf google-cloud-cli-linux-${ARCH}.tar.gz && rm google-cloud-cli-linux-${ARCH}.tar.gz
 RUN google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --additional-components app kubectl alpha beta
 # Disable updater check for the whole installation.
 # Users won't be bugged with notifications to update to the latest version of gcloud.
 RUN google-cloud-sdk/bin/gcloud config set --installation component_manager/disable_update_check true
 
-ENV FILENAME helm-${VERSION}-linux-${TARGETARCH}.tar.gz
-ENV HELM_URL https://get.helm.sh/${FILENAME}
+ENV FILENAME=helm-${VERSION}-linux-${TARGETARCH}.tar.gz
+ENV HELM_URL=https://get.helm.sh/${FILENAME}
 
 RUN echo $HELM_URL
 
@@ -50,7 +50,7 @@ RUN set -x && \
 
 # Install Helm plugins
 # workaround for an issue in updating the binary of `helm-diff`
-ENV HELM_PLUGIN_DIR /.helm/plugins/helm-diff
+ENV HELM_PLUGIN_DIR=/.helm/plugins/helm-diff
 # Plugin is downloaded to /tmp, which must exist
 RUN mkdir /tmp
 RUN helm plugin install https://github.com/viglesiasce/helm-gcs.git


### PR DESCRIPTION
There was still a problem with the kubectl command that could not be executed. Had to add the `gcompat` package because `kubectl` was not statically linked like the other `kubectl` versions in `/google-cloud-sdk/bin/` (see https://github.com/kubernetes/kubernetes/issues/23708)

In addition, the Docker linter warnings are fixed plus the suppression of the wget download progress output. I hope that is okay :-)